### PR TITLE
Fixes Docs Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,8 @@ name: build
 on: 
   push:
   pull_request:
-  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'  # run workflow at 12AM on first day of every month
 
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
         conda activate rivgraph
         python setup.py install
         python -m pip install --upgrade pip
-        pip install sphinx==2.0.1
+        pip install sphinx
         sudo apt update -y && sudo apt install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended dvipng
         pip install sphinx-rtd-theme
         pip install sphinx-gallery

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,10 +4,6 @@ name: docs
 
 on: 
   push:
-    paths:
-      - "rivgraph/**"
-      - "docs/**"
-      - "examples/**"
   pull_request:
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,6 @@ jobs:
       run: |
         mamba env create -q --file environment.yml
         conda activate rivgraph
-        conda uninstall rivgraph
         python setup.py install
         python -m pip install --upgrade pip
         pip install sphinx==2.0.1


### PR DESCRIPTION
@jsta looks like your changes made it so at least the Linux build passes the CI.

I've made some slight modifications to your branch to:

1. Automatically run the CI jobs once a month so we minimize these CI issues in the future / catch them faster
2. Run the docs workflow every time a push is made to the repository
3. Remove pinned version of `sphinx` which (with the removal of `uninstall rivgraph`) fixes the documentation CI

Figure we can merge this here and it'll get incorporated into your open PR